### PR TITLE
Remove unnecessary calls to Presenter's onDestroy

### DIFF
--- a/app/src/main/kotlin/io/github/plastix/kotlinboilerplate/ui/base/PresenterActivity.kt
+++ b/app/src/main/kotlin/io/github/plastix/kotlinboilerplate/ui/base/PresenterActivity.kt
@@ -26,6 +26,9 @@ abstract class PresenterActivity<V : MvpView, T : Presenter<V>> : BaseActivity()
         this.presenter = presenter
     }
 
+    protected fun onPresenterDestroyed() {
+    }
+
     @CallSuper
     override fun onStart() {
         super.onStart()
@@ -57,5 +60,6 @@ abstract class PresenterActivity<V : MvpView, T : Presenter<V>> : BaseActivity()
     }
 
     override fun onLoaderReset(loader: Loader<T>?) {
+        onPresenterDestroyed()
     }
 }

--- a/app/src/main/kotlin/io/github/plastix/kotlinboilerplate/ui/base/PresenterActivity.kt
+++ b/app/src/main/kotlin/io/github/plastix/kotlinboilerplate/ui/base/PresenterActivity.kt
@@ -27,11 +27,6 @@ abstract class PresenterActivity<V : MvpView, T : Presenter<V>> : BaseActivity()
     }
 
     @CallSuper
-    protected fun onPresenterDestroyed() {
-        presenter.onDestroy()
-    }
-
-    @CallSuper
     override fun onStart() {
         super.onStart()
         presenter.bindView(getViewLayer())
@@ -41,13 +36,6 @@ abstract class PresenterActivity<V : MvpView, T : Presenter<V>> : BaseActivity()
     override fun onStop() {
         super.onStop()
         presenter.unbindView()
-    }
-
-    @CallSuper
-    override fun onDestroy() {
-        super.onDestroy()
-        if (isFinishing)
-            onPresenterDestroyed()
     }
 
     protected fun getViewLayer(): V {
@@ -69,7 +57,5 @@ abstract class PresenterActivity<V : MvpView, T : Presenter<V>> : BaseActivity()
     }
 
     override fun onLoaderReset(loader: Loader<T>?) {
-        onPresenterDestroyed()
     }
-
 }


### PR DESCRIPTION
Presenter#onDestory would be called three time in a row, from
Loader's onReset, PresenterActivity's onLoaderReset and onDestory.

Removed calls from PresenterActivity.
